### PR TITLE
feat: How-to-Play Tutorial System (Issue #55)

### DIFF
--- a/src/app/components/GameBoard.tsx
+++ b/src/app/components/GameBoard.tsx
@@ -22,6 +22,7 @@ import { PlayingCard, CardStack } from './PlayingCard';
 import { PalaceDisplay } from './PalaceDisplay';
 import { HowToPlayModal } from './HowToPlayModal';
 import { useSettings } from '../contexts/SettingsContext';
+import { TutorialOverlay, TUTORIAL_STEPS, TUTORIAL_SEEN_KEY } from './TutorialOverlay';
 
 // Seeded random per card ID for consistent rotations
 const DEFAULT_EMOJI = '🦆';
@@ -83,14 +84,17 @@ interface GameBoardProps {
   onStateChange: (state: GameState) => void;
   isMultiplayer?: boolean;
   playerEmoji?: string; // Local player's chosen emoji (for multiplayer emoji sync)
+  tutorialMode?: boolean; // When true, show step-by-step tutorial overlay
 }
 
-export function GameBoard({ gameState, myPlayerId, onStateChange, isMultiplayer, playerEmoji }: GameBoardProps) {
+export function GameBoard({ gameState, myPlayerId, onStateChange, isMultiplayer, playerEmoji, tutorialMode = false }: GameBoardProps) {
   const navigate = useNavigate();
   const [selectedCards, setSelectedCards] = useState<string[]>([]);
   const [error, setError] = useState<string>('');
   const [showLog, setShowLog] = useState(true);
   const [showHelp, setShowHelp] = useState(false);
+  // Tutorial step: 0 = hidden, 1..N = active step
+  const [tutorialStep, setTutorialStep] = useState<number>(() => tutorialMode ? 1 : 0);
   const [animEffect, setAnimEffect] = useState<'slam' | 'sparkle' | 'wipeout' | 'palace-invalid' | 'palace-valid' | 'pickup' | null>(null);
   const [animEmoji, setAnimEmoji] = useState<string | null>(null);
   const [palaceInvalidCard, setPalaceInvalidCard] = useState<Card | null>(null);
@@ -542,6 +546,23 @@ export function GameBoard({ gameState, myPlayerId, onStateChange, isMultiplayer,
   // Pile cards for display (show up to 5 beneath top card)
   const pileCards = gameState.pickupPile.slice(-6);
 
+  // Tutorial handlers
+  const totalTutorialSteps = TUTORIAL_STEPS.length;
+  const handleTutorialNext = () => {
+    if (tutorialStep >= totalTutorialSteps) {
+      // Tutorial complete
+      try { localStorage.setItem(TUTORIAL_SEEN_KEY, 'true'); } catch { /* ignore */ }
+      setTutorialStep(0);
+    } else {
+      setTutorialStep(s => s + 1);
+    }
+  };
+  const handleTutorialSkip = () => {
+    // Skip/dismiss mid-tutorial also marks as seen
+    try { localStorage.setItem(TUTORIAL_SEEN_KEY, 'true'); } catch { /* ignore */ }
+    setTutorialStep(0);
+  };
+
   return (
     <div className="flex flex-col h-full bg-gradient-to-b from-green-900 to-green-800 text-white overflow-visible relative">
       {/* Beginner mode: yellow flash overlay on player's turn */}
@@ -550,6 +571,16 @@ export function GameBoard({ gameState, myPlayerId, onStateChange, isMultiplayer,
         animate={{ opacity: turnFlash ? 0.3 : 0 }}
         transition={{ duration: 0.5 }}
       />
+      {/* Tutorial overlay — shown during guided tutorial mode */}
+      {tutorialMode && tutorialStep > 0 && (
+        <TutorialOverlay
+          step={tutorialStep}
+          totalSteps={totalTutorialSteps}
+          onNext={handleTutorialNext}
+          onSkip={handleTutorialSkip}
+        />
+      )}
+
       {/* Emoji waterfall — background layer, behind all game components */}
       <AnimatePresence>
         {(animEffect === 'wipeout' || animEffect === 'slam' || animEffect === 'sparkle') && animEmoji && (

--- a/src/app/components/TutorialOverlay.tsx
+++ b/src/app/components/TutorialOverlay.tsx
@@ -1,0 +1,149 @@
+import { motion, AnimatePresence } from 'motion/react';
+
+export const TUTORIAL_SEEN_KEY = 'palace-tutorial-seen';
+
+export interface TutorialStep {
+  title: string;
+  body: string;
+  hint?: string;
+  /** Which game phase this step belongs to — informational only */
+  phase: 'setup' | 'playing' | 'endgame';
+}
+
+export const TUTORIAL_STEPS: TutorialStep[] = [
+  {
+    phase: 'setup',
+    title: 'Welcome to Palace! 👑',
+    body: 'Palace is a card-shedding game. Be the first to get rid of all your cards to win — the last player left loses!',
+    hint: 'Tap Next to continue',
+  },
+  {
+    phase: 'setup',
+    title: 'Setting Up Your Palace',
+    body: 'You start with 9 cards. First, pick 3 cards to place face-down in your palace (you can\'t see them — choose blind!). Then pick 3 more to place face-up on top. The remaining 3 go to your hand.',
+    hint: 'Select 3 cards, then tap Confirm Selection',
+  },
+  {
+    phase: 'playing',
+    title: 'Playing Cards',
+    body: 'On your turn, play one or more cards of the same rank onto the pile. You must play equal to or higher than the top pile card. If you can\'t play, pick up the whole pile!',
+    hint: 'Tap a card to select it, then tap Play',
+  },
+  {
+    phase: 'playing',
+    title: '2 — Reset Card',
+    body: 'The 2 is a special "reset" card. You can play it on anything — even an Ace — and it resets the pile rank to 2, letting the next player play almost any card.',
+    hint: 'Look for 2s in your hand — they are always playable!',
+  },
+  {
+    phase: 'playing',
+    title: '10 — Wipeout Card 🔥',
+    body: 'Playing a 10 burns the entire pile (it goes to the discard, not the pickup pile). As a reward, you get a free bonus turn — you can play any card next!',
+    hint: 'After playing a 10, watch the bonus turn prompt appear',
+  },
+  {
+    phase: 'playing',
+    title: 'Four of a Kind — Wipeout! 💥',
+    body: 'Playing four cards of the same rank at once (e.g., four 7s) also burns the pile and earns you a bonus turn. You can build up to four-of-a-kind over multiple plays too!',
+    hint: 'Select all four cards of the same rank, then tap Play',
+  },
+  {
+    phase: 'playing',
+    title: 'Palace Cards 🏰',
+    body: 'Once your hand and the draw pile are empty, you play from your palace. Start with the 3 face-up cards. When those are gone, flip and play the face-down cards one at a time — you don\'t know what you\'ll get!',
+    hint: 'If a face-down card can\'t be played, you pick up the pile',
+  },
+  {
+    phase: 'endgame',
+    title: 'Finishing the Game 🏆',
+    body: 'Clear all your palace cards and you\'re safe! The game ends when only one player still has cards — they\'re the loser. Aim for Gold (1st), Silver (2nd), or Bronze (3rd).',
+    hint: 'Good luck — may the best Palace player win!',
+  },
+];
+
+interface TutorialOverlayProps {
+  step: number; // 1-based; 0 = hidden
+  totalSteps: number;
+  onNext: () => void;
+  onSkip: () => void;
+}
+
+export function TutorialOverlay({ step, totalSteps, onNext, onSkip }: TutorialOverlayProps) {
+  if (step < 1 || step > totalSteps) return null;
+  const tutStep = TUTORIAL_STEPS[step - 1];
+  const isLast = step === totalSteps;
+
+  return (
+    <AnimatePresence mode="wait">
+      <motion.div
+        key={step}
+        className="absolute inset-0 z-50 flex items-end justify-center pb-6 px-4 pointer-events-none"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        transition={{ duration: 0.25 }}
+      >
+        {/* Dim backdrop — only partial so the game is still visible */}
+        <div className="absolute inset-0 bg-black/60 pointer-events-auto" onClick={onNext} />
+
+        {/* Card */}
+        <motion.div
+          className="relative z-10 w-full max-w-sm bg-green-950 border border-yellow-400/40 rounded-2xl p-5 shadow-2xl pointer-events-auto"
+          initial={{ y: 40, opacity: 0 }}
+          animate={{ y: 0, opacity: 1 }}
+          exit={{ y: 40, opacity: 0 }}
+          transition={{ duration: 0.3, ease: 'easeOut' }}
+          onClick={e => e.stopPropagation()}
+        >
+          {/* Progress dots */}
+          <div className="flex gap-1.5 justify-center mb-3">
+            {Array.from({ length: totalSteps }, (_, i) => (
+              <div
+                key={i}
+                className={`h-1.5 rounded-full transition-all ${
+                  i + 1 === step ? 'w-5 bg-yellow-400' : i + 1 < step ? 'w-2.5 bg-yellow-600' : 'w-2.5 bg-white/20'
+                }`}
+              />
+            ))}
+          </div>
+
+          {/* Content */}
+          <h2 className="text-base font-bold text-yellow-300 mb-2 text-center">{tutStep.title}</h2>
+          <p className="text-sm text-green-100 leading-relaxed text-center mb-3">{tutStep.body}</p>
+          {tutStep.hint && (
+            <p className="text-xs text-green-400 italic text-center mb-4">💡 {tutStep.hint}</p>
+          )}
+
+          {/* Buttons */}
+          <div className="flex gap-3">
+            <button
+              onClick={onSkip}
+              className="flex-1 py-2 rounded-xl bg-white/10 text-green-300 text-sm font-semibold hover:bg-white/20 active:scale-[0.98] transition-all"
+            >
+              {isLast ? 'Got it!' : 'Skip'}
+            </button>
+            {!isLast && (
+              <button
+                onClick={onNext}
+                className="flex-1 py-2 rounded-xl bg-yellow-500 text-black text-sm font-bold hover:bg-yellow-400 active:scale-[0.98] transition-all"
+              >
+                Next →
+              </button>
+            )}
+            {isLast && (
+              <button
+                onClick={onNext}
+                className="flex-1 py-2 rounded-xl bg-yellow-500 text-black text-sm font-bold hover:bg-yellow-400 active:scale-[0.98] transition-all"
+              >
+                Play! 🎮
+              </button>
+            )}
+          </div>
+
+          {/* Step counter */}
+          <p className="text-[10px] text-green-600 text-center mt-2">{step} / {totalSteps}</p>
+        </motion.div>
+      </motion.div>
+    </AnimatePresence>
+  );
+}

--- a/src/app/pages/HomePage.tsx
+++ b/src/app/pages/HomePage.tsx
@@ -1,11 +1,88 @@
 import { useState, useRef, useEffect } from 'react';
 import { useNavigate } from 'react-router';
-import { Crown, Bot, Wifi, BookOpen, Settings, RefreshCw, Sparkles } from 'lucide-react';
+import { Crown, Bot, Wifi, BookOpen, Settings, RefreshCw, Sparkles, GraduationCap, X } from 'lucide-react';
 import { MAX_DECKS, MAX_PLAYERS_PER_DECK, PlayerStats, BOT_PROFILES } from '../game-engine';
 import { WHATS_NEW_SEEN_KEY, APP_VERSION } from './WhatsNewPage';
+import { TUTORIAL_SEEN_KEY } from '../components/TutorialOverlay';
 
 const PLAYER_EMOJIS = ['🦆', '🐻', '🦁', '🐸', '🦊', '🐺', '🦝', '🐼', '🦋', '🐠', '🦄', '🐯'];
 const STATS_KEY = 'palace-stats';
+
+/** Swipeable tutorial banner shown to first-time players */
+function TutorialBanner({ onStart, onDismiss }: { onStart: () => void; onDismiss: () => void }) {
+  // Track horizontal drag offset for swipe-to-reveal-dismiss
+  const [dragX, setDragX] = useState(0);
+  const [isDragging, setIsDragging] = useState(false);
+  const startXRef = useRef(0);
+
+  const SWIPE_THRESHOLD = 60; // px to reveal the dismiss button
+  const revealed = Math.abs(dragX) >= SWIPE_THRESHOLD;
+
+  const onPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    setIsDragging(true);
+    startXRef.current = e.clientX;
+    (e.currentTarget as HTMLDivElement).setPointerCapture(e.pointerId);
+  };
+
+  const onPointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!isDragging) return;
+    const delta = e.clientX - startXRef.current;
+    // Allow drag in both directions, clamped to ±110px
+    setDragX(Math.max(-110, Math.min(110, delta)));
+  };
+
+  const onPointerUp = () => {
+    setIsDragging(false);
+    if (!revealed) {
+      // Snap back if not dragged far enough
+      setDragX(0);
+    }
+    // If revealed, keep offset so dismiss button stays visible
+  };
+
+  return (
+    <div className="relative overflow-hidden rounded-xl w-full">
+      {/* Dismiss button revealed by swiping */}
+      <div
+        className={`absolute inset-y-0 flex items-center justify-center transition-opacity ${
+          dragX > 0 ? 'right-0 pr-3' : 'left-0 pl-3'
+        } ${revealed ? 'opacity-100' : 'opacity-0'}`}
+        style={{ width: 64 }}
+      >
+        <button
+          onClick={onDismiss}
+          className="w-10 h-10 rounded-full bg-red-500/80 flex items-center justify-center text-white hover:bg-red-400 active:scale-90 transition-all"
+          aria-label="Dismiss tutorial"
+        >
+          <X className="w-5 h-5" />
+        </button>
+      </div>
+
+      {/* Main banner — slides with drag */}
+      <div
+        className="touch-pan-y select-none flex items-center gap-3 w-full px-5 py-4 bg-yellow-500/20 border border-yellow-400/40 backdrop-blur rounded-xl hover:bg-yellow-500/30 active:scale-[0.98] cursor-pointer"
+        style={{
+          transform: `translateX(${dragX}px)`,
+          transition: isDragging ? 'none' : 'transform 0.25s ease',
+        }}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerCancel={onPointerUp}
+        onClick={() => {
+          if (Math.abs(dragX) < 10) onStart();
+        }}
+      >
+        <GraduationCap className="w-6 h-6 text-yellow-300 shrink-0" />
+        <div className="text-left flex-1">
+          <div className="font-bold text-yellow-100">Learn to Play</div>
+          <div className="text-xs text-yellow-300">Guided tutorial — swipe to dismiss</div>
+        </div>
+        <span className="text-[10px] font-bold bg-yellow-500 text-black px-1.5 py-0.5 rounded-full shrink-0">START</span>
+      </div>
+    </div>
+  );
+}
 
 function formatShortDateTime(ts?: number): string {
   if (!ts) return '';
@@ -39,6 +116,23 @@ export default function HomePage() {
   const [showWhatsNew] = useState<boolean>(() => {
     try { return localStorage.getItem(WHATS_NEW_SEEN_KEY) !== APP_VERSION; } catch { return false; }
   });
+
+  // True for first-time players who haven't dismissed or completed the tutorial
+  const [showTutorial, setShowTutorial] = useState<boolean>(() => {
+    try {
+      const val = localStorage.getItem(TUTORIAL_SEEN_KEY);
+      return val === null; // show only if key has never been set
+    } catch { return false; }
+  });
+
+  const handleTutorialStart = () => {
+    navigate('/robot', { state: { tutorial: true } });
+  };
+
+  const handleTutorialDismiss = () => {
+    try { localStorage.setItem(TUTORIAL_SEEN_KEY, 'dismissed'); } catch { /* ignore */ }
+    setShowTutorial(false);
+  };
 
   // Auto-focus the custom emoji input when it becomes visible
   useEffect(() => {
@@ -205,6 +299,10 @@ export default function HomePage() {
 
       {mode === 'menu' && (
         <div className="flex flex-col gap-3 w-full max-w-xs">
+          {/* Tutorial banner — shown to first-time players */}
+          {showTutorial && (
+            <TutorialBanner onStart={handleTutorialStart} onDismiss={handleTutorialDismiss} />
+          )}
           {/* What's New banner — shown only when user hasn't seen current version's notes */}
           {showWhatsNew && (
             <button

--- a/src/app/pages/RobotGamePage.tsx
+++ b/src/app/pages/RobotGamePage.tsx
@@ -8,9 +8,15 @@ import { HelpCircle } from 'lucide-react';
 export default function RobotGamePage() {
   const location = useLocation();
   const navigate = useNavigate();
-  const { playerNames, playerEmojis, dealerIndex, deckCount } = location.state || { playerNames: ['You', 'Bot 1'], playerEmojis: ['🦆', '⚔️'], dealerIndex: 0, deckCount: 1 };
+  const state = location.state as { playerNames?: string[]; playerEmojis?: string[]; dealerIndex?: number; deckCount?: number; tutorial?: boolean } | null;
+  const tutorial = state?.tutorial ?? false;
 
-  const [gameState, setGameState] = useState<GameState>(() => initGame(playerNames, dealerIndex, deckCount ?? 1, playerEmojis));
+  const playerNames = state?.playerNames ?? ['You', 'Bot 1'];
+  const playerEmojis = state?.playerEmojis ?? ['🦆', '⚔️'];
+  const dealerIndex = state?.dealerIndex ?? 0;
+  const deckCount = state?.deckCount ?? 1;
+
+  const [gameState, setGameState] = useState<GameState>(() => initGame(playerNames, dealerIndex, deckCount, playerEmojis));
   const [showHelp, setShowHelp] = useState(false);
 
   const handleRestart = () => {
@@ -36,6 +42,7 @@ export default function RobotGamePage() {
           myPlayerId="player-0"
           onStateChange={setGameState}
           playerEmoji={playerEmojis?.[0]}
+          tutorialMode={tutorial}
         />
       </div>
     </div>

--- a/src/app/pages/SettingsPage.tsx
+++ b/src/app/pages/SettingsPage.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from 'react-router';
 import { Settings, Volume2, VolumeX, Music, Music2, Maximize, Minimize, Sparkles, Bug, GraduationCap, Lightbulb, History } from 'lucide-react';
 import { useSettings } from '../contexts/SettingsContext';
 import type { GameSettings } from '../contexts/SettingsContext';
+import { TUTORIAL_SEEN_KEY } from '../components/TutorialOverlay';
 
 interface SettingRow {
   key: keyof GameSettings;
@@ -144,20 +145,36 @@ export const SettingsPage: React.FC = () => {
           );
         })}
 
-        {/* Version History link */}
+        {/* Version History & Tutorial links */}
         <div>
           <h2 className="text-xs uppercase tracking-widest text-green-400 mb-2 pl-1">About</h2>
-          <button
-            onClick={() => navigate('/version-log')}
-            className="flex items-center gap-3 w-full px-4 py-3 rounded-xl bg-white/5 border border-white/10 hover:bg-white/10 active:scale-[0.98] transition-all"
-          >
-            <History className="w-5 h-5 text-green-400" />
-            <div className="text-left flex-1">
-              <div className="font-semibold text-sm text-green-300">Version History</div>
-              <div className="text-xs text-green-400">See all past releases</div>
-            </div>
-            <span className="text-green-500 text-sm">→</span>
-          </button>
+          <div className="flex flex-col gap-2">
+            <button
+              onClick={() => navigate('/version-log')}
+              className="flex items-center gap-3 w-full px-4 py-3 rounded-xl bg-white/5 border border-white/10 hover:bg-white/10 active:scale-[0.98] transition-all"
+            >
+              <History className="w-5 h-5 text-green-400" />
+              <div className="text-left flex-1">
+                <div className="font-semibold text-sm text-green-300">Version History</div>
+                <div className="text-xs text-green-400">See all past releases</div>
+              </div>
+              <span className="text-green-500 text-sm">→</span>
+            </button>
+            <button
+              onClick={() => {
+                try { localStorage.removeItem(TUTORIAL_SEEN_KEY); } catch { /* ignore */ }
+                navigate('/');
+              }}
+              className="flex items-center gap-3 w-full px-4 py-3 rounded-xl bg-white/5 border border-white/10 hover:bg-white/10 active:scale-[0.98] transition-all"
+            >
+              <GraduationCap className="w-5 h-5 text-yellow-400" />
+              <div className="text-left flex-1">
+                <div className="font-semibold text-sm text-yellow-300">Tutorial</div>
+                <div className="text-xs text-green-400">Replay the guided tutorial</div>
+              </div>
+              <span className="text-green-500 text-sm">→</span>
+            </button>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Detect first-time players via `localStorage` key `palace-tutorial-seen`
- Show swipeable "Tutorial" button at top of Home Page for new players
- Swipe left/right on button to reveal ✕ dismiss button
- Tutorial launches a guided game walking through key mechanics: special cards (2, 10, four-of-a-kind), bonus turn, palace mechanics, and end-game
- After tutorial completion or dismiss, button is tucked into Settings page
- Settings page row to replay tutorial at any time

## Test plan
- [ ] Fresh browser (clear localStorage) shows Tutorial button on home page
- [ ] Swipe left/right reveals dismiss button; clicking ✕ hides tutorial button permanently
- [ ] Clicking Tutorial button launches guided game with step overlays
- [ ] After tutorial ends, button no longer on home page
- [ ] Settings page has Tutorial row that re-enables the button
- [ ] `npm run build` passes

Closes #55 (first bullet)

https://claude.ai/code/session_013tZZpVBzUcgxPua71gWm9V