### PR TITLE
ui: Rotation on selected cards during palace setup (Issue #62)

### DIFF
--- a/src/app/components/GameBoard.tsx
+++ b/src/app/components/GameBoard.tsx
@@ -919,24 +919,42 @@ export function GameBoard({ gameState, myPlayerId, onStateChange, isMultiplayer,
                 width: 'max-content',
               }}
             >
-            {isSetup && me.setupPhase === 'select-facedown' && me.setupCards.map(card => (
-              <PlayingCard
-                key={card.id}
-                faceDown
-                small
-                selected={selectedCards.includes(card.id)}
-                onClick={() => toggleCard(card.id)}
-              />
-            ))}
-            {isSetup && me.setupPhase === 'select-faceup' && me.setupCards.map(card => (
-              <PlayingCard
-                key={card.id}
-                card={card}
-                small
-                selected={selectedCards.includes(card.id)}
-                onClick={() => toggleCard(card.id)}
-              />
-            ))}
+            {isSetup && me.setupPhase === 'select-facedown' && me.setupCards.map(card => {
+              const isSelected = selectedCards.includes(card.id);
+              const selRotation = isSelected ? getCardRotation(card.id + '-sel', 5) : 0;
+              return (
+                <motion.div
+                  key={card.id}
+                  animate={{ rotate: selRotation, y: isSelected ? -8 : 0 }}
+                  transition={{ duration: 0.15 }}
+                >
+                  <PlayingCard
+                    faceDown
+                    small
+                    selected={isSelected}
+                    onClick={() => toggleCard(card.id)}
+                  />
+                </motion.div>
+              );
+            })}
+            {isSetup && me.setupPhase === 'select-faceup' && me.setupCards.map(card => {
+              const isSelected = selectedCards.includes(card.id);
+              const selRotation = isSelected ? getCardRotation(card.id + '-sel', 5) : 0;
+              return (
+                <motion.div
+                  key={card.id}
+                  animate={{ rotate: selRotation, y: isSelected ? -8 : 0 }}
+                  transition={{ duration: 0.15 }}
+                >
+                  <PlayingCard
+                    card={card}
+                    small
+                    selected={isSelected}
+                    onClick={() => toggleCard(card.id)}
+                  />
+                </motion.div>
+              );
+            })}
             {isPlaying && source === 'hand' && sortedHand.map(card => {
               const isPlayable = playableCardIds.includes(card.id);
               const isSelected = selectedCards.includes(card.id);


### PR DESCRIPTION
## Summary
- During palace setup (both face-down and face-up selection phases), selected cards now animate with a subtle 0–5° rotation
- Uses the existing `getCardRotation()` helper seeded by card ID for stable, deterministic rotations
- Wrapped selected card renders in `motion.div` with `animate={{ rotate, y }}` transition
- Adds physicality to the card selection gesture

## Test plan
- [ ] Start game and observe palace setup phase
- [ ] Clicking/selecting cards shows a slight rotation on selected cards
- [ ] Rotation is stable (no flickering on re-render)
- [ ] Unselected cards have no rotation
- [ ] Applies to both face-down (blind pick) and face-up selection phases
- [ ] `npm run build` passes

Closes #62 (fifth bullet)

https://claude.ai/code/session_013tZZpVBzUcgxPua71gWm9V