### PR TITLE
fix: Confirm particle effects tied to settings toggle (Issue #55)

### DIFF
--- a/src/app/components/GameBoard.tsx
+++ b/src/app/components/GameBoard.tsx
@@ -161,7 +161,9 @@ export function GameBoard({ gameState, myPlayerId, onStateChange, isMultiplayer,
         setPalaceInvalidCard(action.cards[0]);
         setPalaceInvalidPlayerName(playerName);
         setPalaceValidCard(null);
-        setAnimEffect('palace-invalid');
+        if (settings.particleEffects) {
+          setAnimEffect('palace-invalid');
+        }
         if (palaceValidTimerRef.current) { clearTimeout(palaceValidTimerRef.current); palaceValidTimerRef.current = null; }
         if (palaceInvalidTimerRef.current) clearTimeout(palaceInvalidTimerRef.current);
         palaceInvalidTimerRef.current = setTimeout(() => {
@@ -194,7 +196,9 @@ export function GameBoard({ gameState, myPlayerId, onStateChange, isMultiplayer,
       const card = gameState.lastAction.cards[0];
       setPalaceInvalidCard(null);
       setPalaceInvalidPlayerName('');
-      setAnimEffect('palace-valid');
+      if (settings.particleEffects) {
+        setAnimEffect('palace-valid');
+      }
       setPalaceValidCard(card);
       if (palaceInvalidTimerRef.current) { clearTimeout(palaceInvalidTimerRef.current); palaceInvalidTimerRef.current = null; }
       if (palaceValidTimerRef.current) clearTimeout(palaceValidTimerRef.current);
@@ -205,7 +209,7 @@ export function GameBoard({ gameState, myPlayerId, onStateChange, isMultiplayer,
       }, 1500);
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [gameState.lastAction, gameState.version]);
+  }, [gameState.lastAction, gameState.version, settings.particleEffects]);
 
   // Only clear selections when it's not setup phase in multiplayer, or when the turn changes
   useEffect(() => {


### PR DESCRIPTION
## Summary

Audited all `setAnimEffect` calls in `GameBoard.tsx` to confirm they are gated behind `settings.particleEffects`. Found and fixed two cases where animations fired regardless of the toggle:

- **`palace-invalid` animation** (line ~164): `setAnimEffect('palace-invalid')` was called unconditionally inside its own `if` block, outside the existing `settings.particleEffects` guard that covers slam/sparkle/wipeout/pickup. Wrapped with `if (settings.particleEffects)`.
- **`palace-valid` animation** (separate `useEffect`, line ~197): `setAnimEffect('palace-valid')` was in a standalone `useEffect` with no particleEffects guard at all. Wrapped with `if (settings.particleEffects)` and added `settings.particleEffects` to the dependency array.

All other animation triggers (slam, sparkle, wipeout, pickup) were already correctly gated.

## What was checked

- All `setAnimEffect(...)` call sites in `GameBoard.tsx`
- The primary animation `useEffect` (~line 133): correctly gated — no change needed
- The `palace-invalid` path within that same effect (~line 159): **was not gated** — fixed
- The `palace-valid` `useEffect` (~line 185): **was not gated** — fixed
- Build verified with `npm run build` — passes cleanly (pre-existing chunk size warning only)

## Test plan

- [x] Enable Particle Effects in Settings, play a face-down palace card that is invalid — red highlight animation should appear
- [x] Enable Particle Effects in Settings, play a face-down palace card that is valid — green highlight animation should appear
- [x] Disable Particle Effects in Settings, repeat both scenarios — no animations should fire; the card state (palaceInvalidCard / palaceValidCard) still updates correctly for any non-animation UI that depends on it

https://claude.ai/code/session_013tZZpVBzUcgxPua71gWm9V