### PR TITLE
feat: persist player name to localStorage and restore on game setup

### DIFF
--- a/src/app/pages/HomePage.tsx
+++ b/src/app/pages/HomePage.tsx
@@ -101,7 +101,9 @@ export default function HomePage() {
   const navigate = useNavigate();
   const [playerCount, setPlayerCount] = useState(2);
   const [deckCount, setDeckCount] = useState(1);
-  const [playerName, setPlayerName] = useState('');
+  const [playerName, setPlayerName] = useState(() => {
+    try { return localStorage.getItem('palace-player-name') || ''; } catch { return ''; }
+  });
   const [playerEmoji, setPlayerEmoji] = useState(() => {
     try { return localStorage.getItem('palace-player-emoji') || '🦆'; } catch { return '🦆'; }
   });
@@ -216,6 +218,7 @@ export default function HomePage() {
 
   const startRobot = () => {
     if (!playerName.trim()) return;
+    try { localStorage.setItem('palace-player-name', playerName.trim()); } catch { /* ignore */ }
     const names = [playerName.trim()];
     const emojis = [playerEmoji];
 
@@ -231,6 +234,7 @@ export default function HomePage() {
 
   const goMultiplayer = () => {
     if (!playerName.trim()) return;
+    try { localStorage.setItem('palace-player-name', playerName.trim()); } catch { /* ignore */ }
     if (multiAction === 'create') {
       navigate('/lobby', { state: { action: 'create', playerName: playerName.trim(), playerEmoji, playerCount, deckCount } });
     } else {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Player name is now saved to `localStorage` under `palace-player-name` when starting a robot or multiplayer game
- On returning to the robot-setup or multi-setup screen, the saved name is pre-filled automatically
- Follows the same pattern already used for `palace-player-emoji`

## Test plan

- [ ] Enter a player name and start a robot game; navigate back to home — name should be pre-filled
- [ ] Enter a player name and start/join a multiplayer game; navigate back to home — name should be pre-filled
- [ ] Clear localStorage and visit the setup screen — name input should be empty (no regression)
- [ ] Verify emoji persistence is unaffected
EOF
)