### PR TITLE
feat: card rotation animation during palace setup selection

### DIFF
--- a/src/app/components/GameBoard.tsx
+++ b/src/app/components/GameBoard.tsx
@@ -1169,24 +1169,42 @@ export function GameBoard({ gameState, myPlayerId, onStateChange, isMultiplayer,
                 width: 'max-content',
               }}
             >
-            {isSetup && me.setupPhase === 'select-facedown' && me.setupCards.map(card => (
-              <PlayingCard
-                key={card.id}
-                faceDown
-                small
-                selected={selectedCards.includes(card.id)}
-                onClick={() => toggleCard(card.id)}
-              />
-            ))}
-            {isSetup && me.setupPhase === 'select-faceup' && me.setupCards.map(card => (
-              <PlayingCard
-                key={card.id}
-                card={card}
-                small
-                selected={selectedCards.includes(card.id)}
-                onClick={() => toggleCard(card.id)}
-              />
-            ))}
+            {isSetup && me.setupPhase === 'select-facedown' && me.setupCards.map(card => {
+              const isSelected = selectedCards.includes(card.id);
+              const selRotation = isSelected ? getCardRotation(card.id + '-sel', 10) : 0;
+              return (
+                <motion.div
+                  key={card.id}
+                  animate={{ rotate: selRotation, y: isSelected ? -8 : 0 }}
+                  transition={{ duration: 0.15 }}
+                >
+                  <PlayingCard
+                    faceDown
+                    small
+                    selected={isSelected}
+                    onClick={() => toggleCard(card.id)}
+                  />
+                </motion.div>
+              );
+            })}
+            {isSetup && me.setupPhase === 'select-faceup' && me.setupCards.map(card => {
+              const isSelected = selectedCards.includes(card.id);
+              const selRotation = isSelected ? getCardRotation(card.id + '-sel', 10) : 0;
+              return (
+                <motion.div
+                  key={card.id}
+                  animate={{ rotate: selRotation, y: isSelected ? -8 : 0 }}
+                  transition={{ duration: 0.15 }}
+                >
+                  <PlayingCard
+                    card={card}
+                    small
+                    selected={isSelected}
+                    onClick={() => toggleCard(card.id)}
+                  />
+                </motion.div>
+              );
+            })}
             {isPlaying && source === 'hand' && sortedHand.map(card => {
               const isPlayable = playableCardIds.includes(card.id);
               const isSelected = selectedCards.includes(card.id);


### PR DESCRIPTION
## Summary

- During palace setup (face-down and face-up selection phases), selected cards now animate with a subtle random rotation (-10° to +10°) and a slight upward lift (`y: -8`)
- Uses the existing `getCardRotation()` helper (seeded by `card.id + '-sel'`) with `range: 10` for deterministic, stable rotations
- Wraps each setup card's `PlayingCard` in a `motion.div` with `animate={{ rotate, y }}` and `transition={{ duration: 0.15 }}`, matching the pattern already used for hand card selection during gameplay

## Test plan

- [ ] Start a robot game and reach the palace setup phase
- [ ] Click face-down cards — verify each selected card rotates (-10° to +10°) and lifts slightly
- [ ] Deselect a card — verify it animates back to `rotate: 0, y: 0`
- [ ] Confirm selection, then during face-up setup: repeat the same checks
- [ ] Verify the same card always gets the same rotation angle (deterministic)
- [ ] Verify hand card rotation during gameplay still works as before

https://claude.ai/code/session_01HBcmu9WqAn4sVAyEGJffg7