### PR TITLE
feat: v0.7.0 — What's New page, README update, and version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PalaceRoyale
 
-![version](https://img.shields.io/badge/version-0.5.0-yellow)
+![version](https://img.shields.io/badge/version-0.7.0-yellow)
 
 A web-based implementation of the **Palace** card game (also known as Scum or Shed), playable solo against AI or with friends in real-time multiplayer.
 
@@ -56,6 +56,16 @@ npm run build
 | `VITE_SUPABASE_ANON_KEY` | Your Supabase public anon key |
 
 See `.env.example` for the template.
+
+## Update History
+
+### v0.7.0 — March 2026
+
+- **Interactive Tutorial** — First-time players see a swipeable "Learn to Play" banner on the home screen. Tapping it launches a guided game covering special cards (2, 7, 10), bonus turns, palace mechanics, and end-game scenarios. Dismissible by swipe; replayable anytime from Settings.
+- **Chat View in All Game Modes** — The floating opponent overlay (📹) is no longer limited to online multiplayer. It now works in single-player robot games too.
+- **Paginated Hand + Smart Card Sorting** — When your hand exceeds 10 cards it splits into pages with chevron navigation. On your turn, playable cards are automatically sorted to the front for faster decision-making.
+- **Player Name Persistence** — Your name is saved when you start a game and pre-filled on your next visit.
+- **UI Polish & Bug Fixes** — Palace card setup now animates with a tilt and glow. Opponent palace cards display deterministic per-slot rotations. Home page layout refreshed with a horizontal header row and new tagline. Particle effects now correctly respect the Settings toggle (two cases where animations fired unconditionally were fixed).
 
 ## Project Structure
 

--- a/src/app/data/versionHistory.tsx
+++ b/src/app/data/versionHistory.tsx
@@ -180,7 +180,87 @@ function ChatViewMockup() {
   );
 }
 
+// ---- v0.7.0 helper mockups ----
+
+function TutorialMockup() {
+  return (
+    <div className="flex items-center gap-3 bg-yellow-500/20 border border-yellow-400/40 rounded-xl px-4 py-3">
+      <span className="text-2xl">🎓</span>
+      <div className="flex-1 text-left">
+        <div className="font-bold text-yellow-100 text-xs">Learn to Play</div>
+        <div className="text-[10px] text-yellow-300">Guided tutorial — swipe to dismiss</div>
+      </div>
+      <span className="text-[10px] font-bold bg-yellow-500 text-black px-1.5 py-0.5 rounded-full">START</span>
+    </div>
+  );
+}
+
+function PaginatedHandMockup() {
+  return (
+    <div className="flex flex-col items-center gap-2 bg-white/5 rounded-xl p-3">
+      <div className="flex gap-1 items-center">
+        <span className="text-green-400 text-lg">‹</span>
+        {[...'AKQJ1098'].map((r, i) => (
+          <div key={i} className="w-7 h-9 rounded bg-white border border-gray-300 flex items-center justify-center text-[9px] font-bold text-gray-800">{r}</div>
+        ))}
+        <span className="text-green-400 text-lg">›</span>
+      </div>
+      <div className="text-[10px] text-green-400 font-semibold">1 / 2</div>
+    </div>
+  );
+}
+
 // ---- Version content components ----
+
+export function V070Content() {
+  return (
+    <>
+      <FeatureSection emoji="🎓" title="Interactive Tutorial">
+        <p>First-time players are greeted with a swipeable <strong className="text-white">Learn to Play</strong> banner on the home screen. Tapping it launches a guided game that walks through special cards, bonus turns, palace mechanics, and end-game scenarios step by step.</p>
+        <TutorialMockup />
+        <div className="flex flex-wrap gap-1 pt-0.5">
+          <Chip color="yellow">First-time players</Chip>
+          <Chip color="green">Swipe to dismiss</Chip>
+          <Chip color="blue">Replayable in Settings</Chip>
+        </div>
+        <p>Swipe the banner to reveal a dismiss button. Once completed or dismissed, the tutorial can always be replayed from the <strong className="text-white">Settings</strong> page.</p>
+      </FeatureSection>
+
+      <FeatureSection emoji="📹" title="Chat View in Single-Player">
+        <p>The <strong className="text-white">📹 Chat View</strong> floating opponent overlay — previously available only in online multiplayer — now works in all game modes, including solo robot games. Tap the camera icon above your hand to toggle it during any match.</p>
+        <div className="flex flex-wrap gap-1 pt-0.5">
+          <Chip color="purple">All game modes</Chip>
+          <Chip color="blue">Auto-tracks turns</Chip>
+        </div>
+      </FeatureSection>
+
+      <FeatureSection emoji="🃏" title="Paginated Hand & Smart Sorting">
+        <p>When your hand exceeds <strong className="text-white">10 cards</strong>, it splits into pages with left/right chevron navigation. On your turn, <strong className="text-green-300">playable cards</strong> are automatically sorted to the front so you can act faster.</p>
+        <PaginatedHandMockup />
+        <div className="flex flex-wrap gap-1 pt-0.5">
+          <Chip color="green">Playable cards first</Chip>
+          <Chip color="yellow">Page indicator</Chip>
+          <Chip color="blue">Auto-resets on hand change</Chip>
+        </div>
+      </FeatureSection>
+
+      <FeatureSection emoji="💾" title="Player Name Persistence">
+        <p>Your name is now <strong className="text-white">saved automatically</strong> when you start a game and pre-filled on your next visit. No more retyping your name every session.</p>
+      </FeatureSection>
+
+      <FeatureSection emoji="✨" title="Polish & Bug Fixes">
+        <p><strong className="text-white">Card setup animations</strong> — selecting palace cards now animates with a subtle tilt and lift. <strong className="text-white">Selected card glow</strong> adds a yellow shadow highlight during setup. <strong className="text-white">Opponent palace rotations</strong> give each opponent's palace a unique, deterministic tilt.</p>
+        <p><strong className="text-white">Particle effects</strong> now correctly respect the toggle in Settings — two cases where animations fired regardless of the setting have been fixed.</p>
+        <p>The <strong className="text-white">Home Page</strong> received a layout refresh: horizontal crown + title row, left-aligned content, and a new tagline. The footer no longer overlaps page content on taller screens.</p>
+        <div className="flex flex-wrap gap-1 pt-0.5">
+          <Chip color="orange">Bug fix</Chip>
+          <Chip color="green">Visual polish</Chip>
+          <Chip color="yellow">UI improvements</Chip>
+        </div>
+      </FeatureSection>
+    </>
+  );
+}
 
 export function V061Content() {
   return (
@@ -294,6 +374,12 @@ export interface VersionEntry {
  * Add new entries to the TOP of this array with each release.
  */
 export const VERSION_HISTORY: VersionEntry[] = [
+  {
+    version: '0.7.0',
+    date: 'March 2026',
+    summary: 'Interactive tutorial, paginated hand, chat view everywhere & polish',
+    Content: V070Content,
+  },
   {
     version: '0.6.1',
     date: 'March 2026',

--- a/src/app/pages/HomePage.tsx
+++ b/src/app/pages/HomePage.tsx
@@ -319,7 +319,7 @@ export default function HomePage() {
               <Sparkles className="w-6 h-6 text-yellow-300 shrink-0" />
               <div className="text-left flex-1">
                 <div className="font-bold text-yellow-100">What's New in v{APP_VERSION}</div>
-                <div className="text-xs text-yellow-300">Chat View & Version History</div>
+                <div className="text-xs text-yellow-300">Tutorial, paginated hand & more</div>
               </div>
               <span className="text-[10px] font-bold bg-yellow-500 text-black px-1.5 py-0.5 rounded-full shrink-0">NEW</span>
             </button>

--- a/src/app/pages/WhatsNewPage.tsx
+++ b/src/app/pages/WhatsNewPage.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router';
 import { Crown, ArrowLeft, Sparkles, History } from 'lucide-react';
 import { VERSION_HISTORY } from '../data/versionHistory';
 
-const APP_VERSION = '0.6.1';
+const APP_VERSION = '0.7.0';
 export const WHATS_NEW_SEEN_KEY = 'palace-whats-new-seen';
 export { APP_VERSION };
 


### PR DESCRIPTION
## Summary

- Bumps `APP_VERSION` to `0.7.0` in `WhatsNewPage.tsx`, which drives the version shown across the app (footer, What's New banner, seen-key tracking)
- Adds `V070Content` component and a new `0.7.0` entry at the top of `VERSION_HISTORY` in `versionHistory.tsx`, covering all major changes from this release cycle
- Updates `README.md` version badge from `0.5.0` → `0.7.0` and appends a new **Update History → v0.7.0** section
- Updates the What's New banner subtitle in `HomePage.tsx` to reflect v0.7.0 highlights

### v0.7.0 highlights documented

- **Interactive Tutorial** — guided first-play experience with swipe-to-dismiss banner
- **Chat View in all game modes** — floating opponent overlay now works in robot games too
- **Paginated hand + smart card sorting** — pages for 10+ cards; playable cards sorted to front on your turn
- **Player name persistence** — auto-saved and pre-filled on return
- **Polish & bug fixes** — palace setup animations, card glow on selection, particle effects settings fix, home page layout refresh

## Test plan

- [ ] Visit home screen — footer should show `v0.7.0`
- [ ] Confirm What's New banner appears (clear `palace-whats-new-seen` from localStorage first)
- [ ] Navigate to `/whats-new` — verify v0.7.0 content renders with all five sections
- [ ] Navigate to `/version-log` — verify v0.7.0 appears at the top as LATEST, with v0.6.1 and v0.6.0 below it

https://claude.ai/code/session_01CfiZGypMVGC2WCcUjg1JRE