### PR TITLE
feat(ui): animate "1 card left" palace announcement for all players

### DIFF
--- a/src/app/components/GameBoard.tsx
+++ b/src/app/components/GameBoard.tsx
@@ -102,16 +102,19 @@ export function GameBoard({ gameState, myPlayerId, onStateChange, isMultiplayer,
   const [showHelp, setShowHelp] = useState(false);
   // Tutorial step: 0 = hidden, 1..N = active step
   const [tutorialStep, setTutorialStep] = useState<number>(() => tutorialMode ? 1 : 0);
-  const [animEffect, setAnimEffect] = useState<'slam' | 'sparkle' | 'wipeout' | 'palace-invalid' | 'palace-valid' | 'pickup' | null>(null);
+  const [animEffect, setAnimEffect] = useState<'slam' | 'sparkle' | 'wipeout' | 'palace-invalid' | 'palace-valid' | 'pickup' | 'one-card-palace' | null>(null);
   const [animEmoji, setAnimEmoji] = useState<string | null>(null);
   const [palaceInvalidCard, setPalaceInvalidCard] = useState<Card | null>(null);
   const [palaceInvalidPlayerName, setPalaceInvalidPlayerName] = useState<string>('');
   const [palaceValidCard, setPalaceValidCard] = useState<Card | null>(null);
+  const [oneCardPlayerName, setOneCardPlayerName] = useState<string>('');
+  const [oneCardPlayerEmoji, setOneCardPlayerEmoji] = useState<string>('');
   const [handPage, setHandPage] = useState(0);
   const logRef = useRef<HTMLDivElement>(null);
   const prevVersionRef = useRef(gameState.version);
   const palaceInvalidTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const palaceValidTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const oneCardTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const prevNudgeCountRef = useRef(gameState.nudgeCount ?? 0);
   const [miniOpponents, setMiniOpponents] = useState(false);
   const [leaderboardPhase, setLeaderboardPhase] = useState<'game' | 'alltime'>('game');
@@ -171,6 +174,18 @@ export function GameBoard({ gameState, myPlayerId, onStateChange, isMultiplayer,
           setAnimEmoji(emoji);
           setAnimEffect('pickup');
           setTimeout(() => { setAnimEffect(null); setAnimEmoji(null); }, 3000);
+        } else if (action?.type === 'one-card-palace') {
+          const p = gameState.players.find(q => q.id === action.playerId);
+          setOneCardPlayerName(p?.name ?? '');
+          setOneCardPlayerEmoji(p?.emoji ?? DEFAULT_EMOJI);
+          setAnimEffect('one-card-palace');
+          if (oneCardTimerRef.current) clearTimeout(oneCardTimerRef.current);
+          oneCardTimerRef.current = setTimeout(() => {
+            setAnimEffect(null);
+            setOneCardPlayerName('');
+            setOneCardPlayerEmoji('');
+            oneCardTimerRef.current = null;
+          }, 2500);
         }
       }
       if (settings.particleEffects && action?.type === 'palace-invalid' && action.cards?.[0]) {
@@ -181,6 +196,7 @@ export function GameBoard({ gameState, myPlayerId, onStateChange, isMultiplayer,
         if (settings.particleEffects) {
           setAnimEffect('palace-invalid');
         }
+        if (oneCardTimerRef.current) { clearTimeout(oneCardTimerRef.current); oneCardTimerRef.current = null; }
         if (palaceValidTimerRef.current) { clearTimeout(palaceValidTimerRef.current); palaceValidTimerRef.current = null; }
         if (palaceInvalidTimerRef.current) clearTimeout(palaceInvalidTimerRef.current);
         palaceInvalidTimerRef.current = setTimeout(() => {
@@ -194,10 +210,11 @@ export function GameBoard({ gameState, myPlayerId, onStateChange, isMultiplayer,
     }
   }, [gameState.version, settings.particleEffects]);
 
-  // Cleanup palace-invalid and palace-valid timers on unmount
+  // Cleanup palace-invalid, palace-valid, and one-card timers on unmount
   useEffect(() => () => {
     if (palaceInvalidTimerRef.current) clearTimeout(palaceInvalidTimerRef.current);
     if (palaceValidTimerRef.current) clearTimeout(palaceValidTimerRef.current);
+    if (oneCardTimerRef.current) clearTimeout(oneCardTimerRef.current);
   }, []);
 
   // Detect valid palace face-down reveal and trigger palace-valid animEffect
@@ -793,6 +810,50 @@ export function GameBoard({ gameState, myPlayerId, onStateChange, isMultiplayer,
           </motion.div>
         )}
 
+        {animEffect === 'one-card-palace' && (
+          <motion.div
+            key="one-card-palace"
+            className="absolute inset-0 z-40 pointer-events-none flex flex-col items-center justify-center gap-2"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.25 }}
+          >
+            {/* Amber radial glow backdrop */}
+            <motion.div
+              className="absolute inset-0"
+              style={{ background: 'radial-gradient(ellipse at center, rgba(234,179,8,0.20) 0%, transparent 68%)' }}
+            />
+            {/* Player emoji */}
+            <motion.div
+              className="text-5xl z-10"
+              initial={{ scale: 0.3, opacity: 0 }}
+              animate={{ scale: [0.3, 1.3, 1, 1], opacity: [0, 1, 1, 0] }}
+              transition={{ duration: 2.5, times: [0, 0.18, 0.55, 1] }}
+            >
+              {oneCardPlayerEmoji}
+            </motion.div>
+            {/* "1 CARD LEFT!" text */}
+            <motion.div
+              className="text-4xl font-black text-yellow-400 z-10 tracking-wide"
+              style={{ textShadow: '0 0 24px rgba(234,179,8,0.9), 0 0 48px rgba(234,179,8,0.4)' }}
+              initial={{ scale: 2.8, opacity: 0, rotate: -5 }}
+              animate={{ scale: [2.8, 1, 1.05, 1], opacity: [0, 1, 1, 0], rotate: [-5, 0, 1, 0] }}
+              transition={{ duration: 2.5, times: [0, 0.14, 0.50, 1] }}
+            >
+              1 CARD LEFT!
+            </motion.div>
+            {/* Player name subtitle */}
+            <motion.div
+              className="text-base text-amber-200 font-semibold z-10"
+              animate={{ opacity: [0, 1, 1, 0] }}
+              transition={{ duration: 2.5, times: [0, 0.14, 0.72, 1] }}
+            >
+              {oneCardPlayerName}
+            </motion.div>
+          </motion.div>
+        )}
+
       </AnimatePresence>
 
       {/* Debug overlay */}
@@ -1078,8 +1139,10 @@ export function GameBoard({ gameState, myPlayerId, onStateChange, isMultiplayer,
             />
           )}
           {isPlaying && !isFinished && (
-            <div className={`text-sm font-medium px-3 py-1 rounded-full ${animEffect === 'palace-invalid' ? 'bg-red-900/40 text-red-300' : animEffect === 'palace-valid' ? 'bg-green-900/40 text-green-300' : (isMyTurn || hasDrawBonus) ? 'bg-yellow-500/30 text-yellow-200' : 'bg-white/10 text-green-200'}`}>
-              {animEffect === 'palace-invalid'
+            <div className={`text-sm font-medium px-3 py-1 rounded-full ${animEffect === 'palace-invalid' ? 'bg-red-900/40 text-red-300' : animEffect === 'palace-valid' ? 'bg-green-900/40 text-green-300' : animEffect === 'one-card-palace' ? 'bg-yellow-500/30 text-yellow-200' : (isMyTurn || hasDrawBonus) ? 'bg-yellow-500/30 text-yellow-200' : 'bg-white/10 text-green-200'}`}>
+              {animEffect === 'one-card-palace'
+                ? `⚠️ ${oneCardPlayerName}: 1 card left!`
+                : animEffect === 'palace-invalid'
                 ? `❌ ${palaceInvalidPlayerName} picks up the pile!`
                 : animEffect === 'palace-valid'
                   ? '✅ Safe! Face-down card played successfully!'

--- a/src/app/game-engine.ts
+++ b/src/app/game-engine.ts
@@ -46,7 +46,7 @@ export interface GameState {
   winner: string | null;
   eliminated: string[]; // players who cleared all cards (safe)
   loser: string | null; // last player standing = loser
-  lastAction?: { type: 'play' | 'pickup' | 'wipeout' | 'draw' | 'slam' | 'sparkle' | 'nudge' | 'palace-invalid'; cards?: Card[]; playerId?: string } | null;
+  lastAction?: { type: 'play' | 'pickup' | 'wipeout' | 'draw' | 'slam' | 'sparkle' | 'nudge' | 'palace-invalid' | 'one-card-palace'; cards?: Card[]; playerId?: string } | null;
   drawBonus?: { playerId: string } | null; // After playing from hand and drawing, can play cards matching pile top rank
   pendingCounter?: {
     type: 'drawBonus';
@@ -549,6 +549,7 @@ export function playCards(state: GameState, playerId: string, cardIds: string[])
   const s = deepClone(state);
   const player = s.players.find(p => p.id === playerId)!;
   const pIdx = s.players.findIndex(p => p.id === playerId);
+  let oneCardLeftAfterPalace = false;
 
   if (s.phase !== 'playing') throw new Error('Game not in play phase');
   if (pIdx !== s.currentPlayerIndex) throw new Error('Not your turn');
@@ -589,6 +590,7 @@ export function playCards(state: GameState, playerId: string, cardIds: string[])
     // Valid - add to pile
     s.pickupPile.push(card);
     s.log.push(`${player.name} plays ${cardDisplay(card)} from palace face-down.`);
+    if (player.palace.filter(sl => sl.faceDown !== null).length === 1) oneCardLeftAfterPalace = true;
   } else {
     // Normal play from hand or palace face-up
     cards = cardIds.map(id => {
@@ -691,20 +693,20 @@ export function playCards(state: GameState, playerId: string, cardIds: string[])
   drawCards(s, playerId);
 
   if (handleElimination(s, playerId)) {
-    s.lastAction = { type: 'play', cards, playerId };
+    s.lastAction = { type: oneCardLeftAfterPalace ? 'one-card-palace' : 'play', cards, playerId };
     s.version++;
     return s;
   }
 
   // Bonus: if hand matches pile top rank, offer one bonus play before passing turn
   if (trySetDrawBonus(s, playerId)) {
-    s.lastAction = { type: 'play', cards, playerId };
+    s.lastAction = { type: oneCardLeftAfterPalace ? 'one-card-palace' : 'play', cards, playerId };
     s.version++;
     return s;
   }
 
   advanceTurn(s);
-  s.lastAction = { type: 'play', cards, playerId };
+  s.lastAction = { type: oneCardLeftAfterPalace ? 'one-card-palace' : 'play', cards, playerId };
   s.version++;
   return s;
 }
@@ -712,6 +714,7 @@ export function playCards(state: GameState, playerId: string, cardIds: string[])
 export function playBonusAction(state: GameState, playerId: string, cardIds: string[]): GameState {
   const s = deepClone(state);
   const player = s.players.find(p => p.id === playerId)!;
+  let oneCardLeftAfterPalace = false;
 
   if (!s.waitingForBonus) throw new Error('No bonus action pending');
   if (cardIds.length === 0) throw new Error('Must play at least one card');
@@ -744,6 +747,7 @@ export function playBonusAction(state: GameState, playerId: string, cardIds: str
     }
 
     s.pickupPile.push(card);
+    if (player.palace.filter(sl => sl.faceDown !== null).length === 1) oneCardLeftAfterPalace = true;
   } else {
     cards = cardIds.map(id => {
       if (source === 'hand') return player.hand.find(c => c.id === id)!;
@@ -830,20 +834,20 @@ export function playBonusAction(state: GameState, playerId: string, cardIds: str
   drawCards(s, playerId);
 
   if (handleElimination(s, playerId)) {
-    s.lastAction = { type: 'play', cards, playerId };
+    s.lastAction = { type: oneCardLeftAfterPalace ? 'one-card-palace' : 'play', cards, playerId };
     s.version++;
     return s;
   }
 
   // Bonus: if hand matches pile top rank after bonus action, offer one more bonus play
   if (trySetDrawBonus(s, playerId)) {
-    s.lastAction = { type: 'play', cards, playerId };
+    s.lastAction = { type: oneCardLeftAfterPalace ? 'one-card-palace' : 'play', cards, playerId };
     s.version++;
     return s;
   }
 
   advanceTurn(s);
-  s.lastAction = { type: 'play', cards, playerId };
+  s.lastAction = { type: oneCardLeftAfterPalace ? 'one-card-palace' : 'play', cards, playerId };
   s.version++;
   return s;
 }
@@ -1050,6 +1054,7 @@ export function stealTurn(state: GameState, stealingPlayerId: string, cardIds: s
 // Counter player plays a valid card, cancelling the pending bonus
 export function playCounter(state: GameState, playerId: string, cardIds: string[]): GameState {
   const s = deepClone(state);
+  let oneCardLeftAfterPalace = false;
   if (!s.pendingCounter) throw new Error('No counter opportunity pending');
 
   const pIdx = s.players.findIndex(p => p.id === playerId);
@@ -1087,6 +1092,7 @@ export function playCounter(state: GameState, playerId: string, cardIds: string[
       return s;
     }
     s.pickupPile.push(card);
+    if (player.palace.filter(sl => sl.faceDown !== null).length === 1) oneCardLeftAfterPalace = true;
   } else {
     cards = cardIds.map(id => {
       if (source === 'hand') {
@@ -1174,19 +1180,19 @@ export function playCounter(state: GameState, playerId: string, cardIds: string[
   drawCards(s, playerId);
 
   if (handleElimination(s, playerId)) {
-    s.lastAction = { type: 'play', cards, playerId };
+    s.lastAction = { type: oneCardLeftAfterPalace ? 'one-card-palace' : 'play', cards, playerId };
     s.version++;
     return s;
   }
 
   if (trySetDrawBonus(s, playerId)) {
-    s.lastAction = { type: 'play', cards, playerId };
+    s.lastAction = { type: oneCardLeftAfterPalace ? 'one-card-palace' : 'play', cards, playerId };
     s.version++;
     return s;
   }
 
   advanceTurn(s);
-  s.lastAction = { type: 'play', cards, playerId };
+  s.lastAction = { type: oneCardLeftAfterPalace ? 'one-card-palace' : 'play', cards, playerId };
   s.version++;
   return s;
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds a 2.5s fullscreen amber overlay animation that fires for **all connected clients** whenever any player plays a face-down palace card and is left with exactly one remaining
- Animation shows the player's emoji, bold "1 CARD LEFT!" text (yellow glow), and the player's name as a subtitle
- Status badge below the pile also updates to show `⚠️ {playerName}: 1 card left!` during the animation
- Respects the existing **Particle Effects** toggle in Settings
- Works in both robot (single-player) and online multiplayer games

## How it works

**`game-engine.ts`**
- Adds `'one-card-palace'` to the `lastAction.type` union
- In `playCards()`, `playBonusAction()`, and `playCounter()`: after a valid blind palace-facedown play, counts remaining face-down slots; if exactly 1 remains, emits `lastAction = { type: 'one-card-palace', ... }` instead of `'play'`
- Invalid plays, slams (10), and wipeouts (4-of-a-kind) still emit their existing action types and take precedence

**`GameBoard.tsx`**
- Extends `animEffect` state type with `'one-card-palace'`
- New state (`oneCardPlayerName`, `oneCardPlayerEmoji`) and timer ref
- Animation trigger in the version-change `useEffect` (inside `particleEffects` guard)
- `AnimatePresence` overlay with amber radial glow, scale-in emoji, zooming text, and fading name
- Timer cleanup on unmount and when `palace-invalid` fires

## Test plan

- [ ] Start a multiplayer game; get a player into the face-down palace phase (hand empty, draw pile empty, all face-up cards played)
- [ ] Play a face-down card when 2 slots are occupied → **"1 CARD LEFT!"** overlay appears on all connected screens
- [ ] Play the final face-down card → overlay does NOT fire (0 remain); standard `palace-valid` green animation shows instead
- [ ] Play an invalid face-down card → `palace-invalid` red shake fires, NOT the one-card overlay
- [ ] Toggle off Particle Effects in Settings → overlay does not appear
- [ ] Verify in single-player (robot game) as well

https://claude.ai/code/session_016iNeGuQBeVzsBew1axnyfi
EOF
)