### PR TITLE
refactor: make player emoji required in multiplayer flow

### DIFF
--- a/src/app/components/GameBoard.tsx
+++ b/src/app/components/GameBoard.tsx
@@ -825,7 +825,7 @@ export function GameBoard({ gameState, myPlayerId, onStateChange, isMultiplayer,
         >
           {/* Opponent info */}
           <div className="flex items-center gap-1.5 px-2 pt-2 pb-1">
-            <span className="text-base leading-none">{chatOpponent.emoji || DEFAULT_EMOJI}</span>
+            <span className="text-base leading-none">{chatOpponent.emoji}</span>
             <span className={`text-[10px] font-bold truncate flex-1 ${
               (gameState.eliminated || []).includes(chatOpponent.id) ? 'text-green-300' :
               currentPlayer?.id === chatOpponent.id ? 'text-yellow-300' : 'text-white'
@@ -871,7 +871,7 @@ export function GameBoard({ gameState, myPlayerId, onStateChange, isMultiplayer,
               return (
                 <>
                   <div className="flex items-center gap-1 mt-0.5">
-                    <span className="text-[11px]">{lastPlayedPlayer.emoji || DEFAULT_EMOJI}</span>
+                    <span className="text-[11px]">{lastPlayedPlayer.emoji}</span>
                     <span className="text-[9px] text-white font-medium truncate">{lastPlayedPlayer.name}</span>
                   </div>
                   {lastPlayedStatsText && (
@@ -891,7 +891,7 @@ export function GameBoard({ gameState, myPlayerId, onStateChange, isMultiplayer,
                 if (!ep) return null;
                 return (
                   <div key={pid} className="flex items-center gap-1 mt-0.5">
-                    <span className="text-[11px]">{ep.emoji || DEFAULT_EMOJI}</span>
+                    <span className="text-[11px]">{ep.emoji}</span>
                     <span className="text-[9px] text-white font-medium truncate flex-1">{ep.name}</span>
                     <span className="text-[8px] text-yellow-300 shrink-0">{getRankLabel(pid, gameState.eliminated)}</span>
                   </div>
@@ -1358,7 +1358,7 @@ export function GameBoard({ gameState, myPlayerId, onStateChange, isMultiplayer,
                 className="px-3 py-1.5 bg-white/10 text-xl rounded-lg hover:bg-white/20 active:scale-90 transition-all"
                 title={`Nudge ${currentPlayer.name}`}
               >
-                {currentPlayer.emoji || DEFAULT_EMOJI}
+                {currentPlayer.emoji}
               </button>
             )}
           </div>
@@ -1434,7 +1434,7 @@ function OpponentView({ player, isCurrentTurn, isSetup, isEliminated, eliminated
       'bg-black/10'
     }`}>
       <span className="text-[10px] font-bold truncate max-w-26 mb-1">
-        {player.emoji || DEFAULT_EMOJI} {player.name} {isEliminated ? '✅' : isCurrentTurn ? '⭐' : ''}
+        {player.emoji} {player.name} {isEliminated ? '✅' : isCurrentTurn ? '⭐' : ''}
       </span>
       {isSetup ? (
         <span className="text-[10px] text-green-300">
@@ -1530,7 +1530,7 @@ function GameEndLeaderboard({ gameState, myPlayerId, phase, onNext, onHome }: {
       {myPlayer?.stats && (
         <div className="bg-yellow-500/20 rounded-xl px-3 py-2 text-sm">
           <div className="font-bold text-yellow-200 mb-1">
-            {myPlayer.emoji || DEFAULT_EMOJI} {myPlayer.name} ({myRankIndex >= 0 ? (medals[myRankIndex] || '💀') : '—'} this game)
+            {myPlayer.emoji} {myPlayer.name} ({myRankIndex >= 0 ? (medals[myRankIndex] || '💀') : '—'} this game)
           </div>
           <div className="flex justify-center gap-3 text-xs">
             <span>🥇 {myPlayer.stats.gold}</span>
@@ -1546,7 +1546,7 @@ function GameEndLeaderboard({ gameState, myPlayerId, phase, onNext, onHome }: {
           <div className="text-[10px] text-green-400 font-semibold">Other Players</div>
           {gameState.players.filter(p => p.id !== myPlayerId && p.stats).map(p => (
             <div key={p.id} className="flex items-center gap-2 px-2 py-1.5 bg-white/10 rounded-lg text-xs">
-              <span>{p.emoji || DEFAULT_EMOJI}</span>
+              <span>{p.emoji}</span>
               <span className="flex-1 text-left truncate">{p.name}</span>
               {p.stats && (
                 <span className="text-yellow-300 text-[9px]">{formatStatsText(p.stats)}</span>

--- a/src/app/game-engine.ts
+++ b/src/app/game-engine.ts
@@ -24,7 +24,7 @@ export interface PlayerStats {
 export interface Player {
   id: string;
   name: string;
-  emoji?: string; // Player's chosen emoji avatar
+  emoji: string; // Player's chosen emoji avatar
   hand: Card[];
   palace: PalaceSlot[];
   setupPhase: 'select-facedown' | 'select-faceup' | 'done';
@@ -145,7 +145,7 @@ export function shuffle<T>(arr: T[]): T[] {
 
 // ---- Game Init ----
 
-export function initGame(playerNames: string[], dealerIndex: number = 0, numberOfDecks: number = 1, playerEmojis?: string[]): GameState {
+export function initGame(playerNames: string[], dealerIndex: number = 0, numberOfDecks: number = 1, playerEmojis: string[]): GameState {
   const clampedDecks = Math.max(1, Math.min(MAX_DECKS, numberOfDecks));
   const combined: Card[] = [];
   for (let d = 0; d < clampedDecks; d++) {
@@ -155,7 +155,7 @@ export function initGame(playerNames: string[], dealerIndex: number = 0, numberO
   const players: Player[] = playerNames.map((name, i) => ({
     id: `player-${i}`,
     name,
-    emoji: playerEmojis?.[i],
+    emoji: playerEmojis[i],
     hand: [],
     palace: [
       { faceDown: null, faceUp: null },
@@ -1496,7 +1496,7 @@ export function revealFaceDownCards(state: GameState, playerId: string): GameSta
 // Reset game for rematch — same players, new deal. Loser deals.
 export function resetGame(state: GameState, numberOfDecks: number = state.numberOfDecks ?? 1): GameState {
   const playerNames = state.players.map(p => p.name);
-  const playerEmojis = state.players.map(p => p.emoji || '🦆');
+  const playerEmojis = state.players.map(p => p.emoji);
   const playerStats = state.players.map(p => p.stats);
 
   // Loser deals next game

--- a/src/app/pages/LobbyPage.tsx
+++ b/src/app/pages/LobbyPage.tsx
@@ -16,8 +16,7 @@ export default function LobbyPage() {
 
   const [gameCode, setGameCode] = useState('');
   const [playerId, setPlayerId] = useState('');
-  const [players, setPlayers] = useState<{ id: string; name: string; emoji?: string }[]>([]);
-  const [playerEmojiMap, setPlayerEmojiMap] = useState<Record<string, string>>({});
+  const [players, setPlayers] = useState<{ id: string; name: string; emoji: string }[]>([]);
   const [expectedCount, setExpectedCount] = useState(playerCount || 2);
   const [error, setError] = useState('');
   const [copied, setCopied] = useState(false);
@@ -52,7 +51,6 @@ export default function LobbyPage() {
       setGameCode(data.code);
       setPlayerId(data.playerId);
       setPlayers([{ id: data.playerId, name: playerName, emoji: myEmoji }]);
-      setPlayerEmojiMap({ [data.playerId]: myEmoji });
       setExpectedCount(playerCount);
       setLoading(false);
       startPolling(data.code, data.playerId, myEmoji);
@@ -74,12 +72,6 @@ export default function LobbyPage() {
       setGameCode(joinCode);
       setPlayerId(data.playerId);
       setPlayers(data.players);
-      // Build emoji map from server player records
-      const emojiMap: Record<string, string> = {};
-      (data.players as { id: string; name: string; emoji?: string }[]).forEach(p => {
-        emojiMap[p.id] = p.emoji || DEFAULT_EMOJI_FALLBACK;
-      });
-      setPlayerEmojiMap(emojiMap);
       setLoading(false);
 
       // Get expected count
@@ -102,13 +94,6 @@ export default function LobbyPage() {
         if (!res.ok) return;
         setPlayers(data.players);
         setExpectedCount(data.playerCount);
-        // Rebuild emoji map fully from server data on every poll so new players'
-        // emojis are immediately visible to both host and non-host players
-        const emojiMap: Record<string, string> = {};
-        (data.players as { id: string; name: string; emoji?: string }[]).forEach(p => {
-          emojiMap[p.id] = p.emoji || DEFAULT_EMOJI_FALLBACK;
-        });
-        setPlayerEmojiMap(emojiMap);
 
         // Check if game started
         if (data.state) {
@@ -123,7 +108,7 @@ export default function LobbyPage() {
     // Host starts the game
     const playerNames = players.map(p => p.name);
     // Read emojis from server player records
-    const emojis = players.map(p => p.emoji || playerEmojiMap[p.id] || DEFAULT_EMOJI_FALLBACK);
+    const emojis = players.map(p => p.emoji);
     // Use host's explicit deck selection directly — do not cap by player count.
     // The host may intentionally use multiple decks with a smaller group.
     const state = initGame(playerNames, 0, deckCount ?? 1, emojis);
@@ -137,7 +122,7 @@ export default function LobbyPage() {
         throw new Error(data.error);
       }
       clearInterval(pollRef.current);
-      navigate('/multiplayer', { state: { code: gameCode, playerId, playerEmoji: players.find(p => p.id === playerId)?.emoji || playerEmojiMap[playerId] || DEFAULT_EMOJI_FALLBACK, gameState: state } });
+      navigate('/multiplayer', { state: { code: gameCode, playerId, playerEmoji: players.find(p => p.id === playerId)!.emoji, gameState: state } });
     } catch (e: any) {
       setError(e.message);
     }
@@ -192,7 +177,7 @@ export default function LobbyPage() {
         {players.map((p, i) => (
           <div key={p.id} className="flex items-center gap-3 px-4 py-3 bg-white/10 rounded-xl">
             <div className="w-8 h-8 bg-yellow-500 rounded-full flex items-center justify-center text-lg">
-              {p.emoji || playerEmojiMap[p.id] || p.name[0]}
+              {p.emoji}
             </div>
             <span className="font-medium">{p.name}</span>
             {i === 0 && <span className="text-[10px] bg-yellow-500/30 text-yellow-300 px-2 py-0.5 rounded-full ml-auto">Host</span>}

--- a/src/app/pages/RobotGamePage.tsx
+++ b/src/app/pages/RobotGamePage.tsx
@@ -41,7 +41,7 @@ export default function RobotGamePage() {
           gameState={gameState}
           myPlayerId="player-0"
           onStateChange={setGameState}
-          playerEmoji={playerEmojis?.[0]}
+          playerEmoji={playerEmojis[0]}
           tutorialMode={tutorial}
         />
       </div>


### PR DESCRIPTION
## Summary

- Make `emoji` a required field on the `Player` interface in `game-engine.ts` (was optional `emoji?: string`)
- Remove the redundant `playerEmojiMap` state from `LobbyPage.tsx` — emoji is already on each player object from the server
- Simplify triple-fallback chains (`p.emoji || playerEmojiMap[p.id] || DEFAULT_EMOJI_FALLBACK`) to direct `p.emoji` access
- Remove unnecessary `|| DEFAULT_EMOJI` fallbacks in `GameBoard.tsx` where the player variable is guaranteed to be a `Player` object

## Test plan

- [ ] Run `npm run build` — passes with no TypeScript errors
- [ ] Start a robot game and verify emoji displays correctly for player and bots
- [ ] Create a multiplayer lobby and verify the lobby JSON includes `emoji` in the `players` array
- [ ] Join with a second player and verify both emojis display in the lobby UI
- [ ] Start the game and verify emojis carry through to the game board

https://claude.ai/code/session_012vi7mrjPyyq8fCw3XN5rH6