### PR TITLE
Auto-create profiles via database trigger on auth signup

### DIFF
--- a/src/app/contexts/AuthContext.tsx
+++ b/src/app/contexts/AuthContext.tsx
@@ -124,10 +124,21 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const defaultStats: PlayerStats = { gold: 0, silver: 0, bronze: 0, losses: 0, gamesPlayed: 0 };
     const rankings = importStats ?? defaultStats;
 
-    // Sign up with Supabase Auth
+    // Sign up with Supabase Auth.
+    // Pass profile fields via options.data so they are stored in
+    // auth.users.raw_user_meta_data. The database trigger
+    // (handle_new_user) reads them to auto-create the profiles row.
     const { data: authData, error: authError } = await supabase.auth.signUp({
       email,
       password,
+      options: {
+        data: {
+          username: username.toLowerCase(),
+          nickname,
+          emoji,
+          rankings,
+        },
+      },
     });
 
     if (authError) {
@@ -139,25 +150,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     if (!authData.user) {
       return { error: 'Sign-up failed. Please try again.' };
-    }
-
-    // Insert profile row
-    const { error: profileError } = await supabase
-      .from('profiles')
-      .insert({
-        id: authData.user.id,
-        username: username.toLowerCase(),
-        nickname,
-        emoji,
-        rankings,
-      });
-
-    if (profileError) {
-      // Clean up: if profile insert fails, still allow the user to continue
-      // The profile might already exist if there was a race condition
-      if (!profileError.message.includes('duplicate key')) {
-        return { error: 'Account created but profile setup failed. Please sign in and try again.' };
-      }
     }
 
     setUser(authData.user);

--- a/supabase/migrations/001_profiles.sql
+++ b/supabase/migrations/001_profiles.sql
@@ -1,5 +1,7 @@
--- Profiles table
-CREATE TABLE profiles (
+-- Profiles table (public schema)
+-- References Supabase Auth's auth.users table.
+-- A trigger auto-creates a row here whenever a new user signs up.
+CREATE TABLE public.profiles (
   id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
   username TEXT UNIQUE NOT NULL,
   nickname TEXT NOT NULL DEFAULT '',
@@ -10,22 +12,54 @@ CREATE TABLE profiles (
   created_at TIMESTAMPTZ DEFAULT now()
 );
 
--- RLS policies
-ALTER TABLE profiles ENABLE ROW LEVEL SECURITY;
+-- Trigger function: auto-create a profile row when a new auth user is created.
+-- Reads username, nickname, emoji, and optional imported rankings from
+-- the raw_user_meta_data that was passed via signUp({ options: { data: {...} } }).
+-- Uses SECURITY DEFINER so it can write to public.profiles on behalf of the
+-- supabase_auth_admin role that performs the insert into auth.users.
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  INSERT INTO public.profiles (id, username, nickname, emoji, rankings)
+  VALUES (
+    new.id,
+    COALESCE(new.raw_user_meta_data ->> 'username', ''),
+    COALESCE(new.raw_user_meta_data ->> 'nickname', ''),
+    COALESCE(new.raw_user_meta_data ->> 'emoji', '🦆'),
+    COALESCE(
+      (new.raw_user_meta_data -> 'rankings')::jsonb,
+      '{"gold":0,"silver":0,"bronze":0,"losses":0,"gamesPlayed":0}'::jsonb
+    )
+  );
+  RETURN new;
+END;
+$$;
 
--- Users can read their own profile
-CREATE POLICY "Users can read own profile"
-  ON profiles FOR SELECT USING (auth.uid() = id);
+-- Fire the trigger after every new auth user row is inserted.
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW
+  EXECUTE FUNCTION public.handle_new_user();
+
+-- RLS policies
+ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
+
+-- Anyone can look up profiles (for leaderboard, friend search, multiplayer display).
+-- Sensitive data (email, etc.) lives in auth.users, not here.
+CREATE POLICY "Public profiles are viewable by everyone"
+  ON public.profiles FOR SELECT
+  USING (true);
 
 -- Users can update their own profile
 CREATE POLICY "Users can update own profile"
-  ON profiles FOR UPDATE USING (auth.uid() = id);
+  ON public.profiles FOR UPDATE
+  USING (auth.uid() = id);
 
--- Users can insert their own profile (on signup)
+-- Users can insert their own profile (fallback if trigger didn't fire)
 CREATE POLICY "Users can insert own profile"
-  ON profiles FOR INSERT WITH CHECK (auth.uid() = id);
-
--- Anyone can look up a profile by username (for friend requests)
--- Returns limited columns via Edge Function, not direct table access
-CREATE POLICY "Public username lookup"
-  ON profiles FOR SELECT USING (true);
+  ON public.profiles FOR INSERT
+  WITH CHECK (auth.uid() = id);


### PR DESCRIPTION
## Summary
Refactored profile creation to use a database trigger instead of client-side insertion. Profile data is now passed through Supabase Auth's `raw_user_meta_data` during signup, and a `SECURITY DEFINER` trigger automatically creates the corresponding profile row when a new auth user is created.

## Key Changes
- **Database Migration (`001_profiles.sql`)**
  - Added comprehensive documentation to the profiles table and RLS policies
  - Created `handle_new_user()` trigger function that reads profile fields from `auth.users.raw_user_meta_data` and inserts them into `public.profiles`
  - Added `on_auth_user_created` trigger to fire the function after each new auth user insertion
  - Changed SELECT policy from "Users can read own profile" to "Public profiles are viewable by everyone" to support leaderboards and friend search
  - Consolidated duplicate SELECT policies into a single public-facing policy
  - Added explicit `public.` schema qualification to all table references

- **Auth Context (`src/app/contexts/AuthContext.tsx`)**
  - Modified signup flow to pass profile fields (`username`, `nickname`, `emoji`, `rankings`) via `options.data` in the `signUp()` call
  - Removed manual profile insertion logic that previously made a separate database call
  - Eliminated race condition risk by relying on the atomic trigger-based approach
  - Simplified error handling by removing profile-specific error cases

## Implementation Details
- The trigger uses `SECURITY DEFINER` with `SET search_path = ''` to safely execute with elevated privileges on behalf of the auth admin role
- Default values are applied in the trigger (e.g., emoji defaults to 🦆, rankings defaults to zero stats)
- The INSERT policy on profiles remains as a fallback in case the trigger doesn't fire
- Profile data is now part of the auth user's metadata, making it available throughout the auth lifecycle

https://claude.ai/code/session_01QDVqmLifn7yfuUkDvY2uNo