### PR TITLE
Add fast-forward skip button for eliminated players in robot mode

### DIFF
--- a/src/app/components/GameBoard.tsx
+++ b/src/app/components/GameBoard.tsx
@@ -132,6 +132,7 @@ export function GameBoard({ gameState, myPlayerId, onStateChange, isMultiplayer,
   const isPlaying = gameState.phase === 'playing';
   const isFinished = gameState.phase === 'finished';
   const isEliminated = (gameState.eliminated || []).includes(myPlayerId);
+  const isFastForward = isEliminated && !isMultiplayer && isPlaying;
   // During multiplayer setup, defer opponent status until local player finishes
   const deferredSetup = isMultiplayer && isSetup && me.setupPhase !== 'done';
 
@@ -290,9 +291,11 @@ export function GameBoard({ gameState, myPlayerId, onStateChange, isMultiplayer,
     // Get current player's bot profile for variable timing
     const currentPlayer = gameState.players[gameState.currentPlayerIndex];
     const botProfile = getBotProfile(currentPlayer.name);
-    const aiDelay = botProfile
-      ? getRandomBotDelay(botProfile)
-      : Math.floor(800 + Math.random() * 800); // fallback: 800–1600ms random
+    const aiDelay = isFastForward
+      ? 150
+      : botProfile
+        ? getRandomBotDelay(botProfile)
+        : Math.floor(800 + Math.random() * 800); // fallback: 800–1600ms random
 
     const timer = setTimeout(() => {
       try {
@@ -311,7 +314,7 @@ export function GameBoard({ gameState, myPlayerId, onStateChange, isMultiplayer,
       } catch (e) { console.log('AI error:', e); }
     }, aiDelay);
     return () => clearTimeout(timer);
-  }, [gameState.version, isMyTurn, isPlaying, isMultiplayer]);
+  }, [gameState.version, isMyTurn, isPlaying, isMultiplayer, isFastForward]);
 
   // AI setup for robot mode
   useEffect(() => {
@@ -469,6 +472,25 @@ export function GameBoard({ gameState, myPlayerId, onStateChange, isMultiplayer,
       setSelectedCards([]);
       onStateChange(newState);
     } catch (e: any) { setError(e.message); }
+  };
+
+  const handleSkipToEnd = () => {
+    let s = gameState;
+    let safety = 0;
+    while (s.phase !== 'finished' && safety < 10000) {
+      const stealState = checkAISteal(s);
+      if (stealState) { s = stealState; safety++; continue; }
+      if (s.pendingCounter) {
+        const cp = s.players[s.currentPlayerIndex];
+        s = aiHandleCounter(s, getBotProfile(cp.name));
+        safety++;
+        continue;
+      }
+      const cp = s.players[s.currentPlayerIndex];
+      s = aiPlayTurn(s, getBotProfile(cp.name));
+      safety++;
+    }
+    onStateChange(s);
   };
 
   const handleFaceDownPlay = (slotIndex: number) => {
@@ -1376,6 +1398,18 @@ export function GameBoard({ gameState, myPlayerId, onStateChange, isMultiplayer,
           </div>
         )}
 
+        {/* Fast-forward skip button - shown when human is eliminated in robot mode */}
+        {isFastForward && !isFinished && (
+          <div className="flex gap-2 justify-center pt-1">
+            <button
+              onClick={handleSkipToEnd}
+              className="px-4 py-1.5 bg-white/20 text-white rounded-lg font-bold text-sm hover:bg-white/30 active:scale-95 transition-all"
+            >
+              Skip ⏩
+            </button>
+          </div>
+        )}
+
         {/* Action buttons - below hand */}
         {isPlaying && !isFinished && !isEliminated && (
           <div className="flex gap-2 justify-center pt-1">
@@ -1425,6 +1459,18 @@ export function GameBoard({ gameState, myPlayerId, onStateChange, isMultiplayer,
                 {currentPlayer.emoji || DEFAULT_EMOJI}
               </button>
             )}
+          </div>
+        )}
+
+        {/* New Game button - robot mode, shown when game is finished */}
+        {isFinished && !isMultiplayer && leaderboardPhase === 'alltime' && (
+          <div className="flex gap-2 justify-center pt-1">
+            <button
+              onClick={() => onStateChange(resetGame(gameState))}
+              className="px-5 py-2 bg-yellow-500 text-black rounded-lg font-bold text-sm hover:bg-yellow-400 active:scale-95 transition-all"
+            >
+              🔄 New Game
+            </button>
           </div>
         )}
 


### PR DESCRIPTION
## Summary
This PR enhances the single-player robot mode experience by allowing eliminated players to skip ahead to the end of the game rather than waiting for AI opponents to finish playing.

## Key Changes
- **Fast-forward detection**: Added `isFastForward` flag that triggers when the player is eliminated in single-player mode during active gameplay
- **Accelerated AI timing**: Reduced AI delay from 800-1600ms to 150ms when fast-forwarding to speed up game completion
- **Skip button UI**: Added a "Skip ⏩" button that appears only when fast-forward conditions are met
- **Skip implementation**: Implemented `handleSkipToEnd()` function that rapidly simulates remaining AI turns until game completion, with safety limit of 10,000 iterations
- **New Game button**: Added a "🔄 New Game" button in robot mode that appears when the game finishes, allowing quick restart
- **Dependency update**: Added `isFastForward` to the AI turn effect's dependency array to ensure proper re-evaluation

## Implementation Details
- The skip function iterates through AI steal checks, counter handling, and turn execution until the game reaches the 'finished' phase
- Fast-forward mode only activates in single-player (non-multiplayer) games when the current player is eliminated and the game is actively playing
- The safety counter prevents infinite loops during skip execution
- UI elements are conditionally rendered based on game state to maintain clean UX

https://claude.ai/code/session_011sjzWyFxHzmjn7ywjkvzkU